### PR TITLE
Update utility.py

### DIFF
--- a/finlab_crypto/utility.py
+++ b/finlab_crypto/utility.py
@@ -8,12 +8,23 @@ import vectorbt as vbt
 import seaborn as sns
 import pandas as pd
 import numpy as np
+import numbers
 import copy
 import os
 
 from . import chart
 from . import overfitting
 
+
+def crossover(s1, s2):
+    if isinstance(s2, numbers.Number):
+        return (s1 > s2) & (s1.shift() < s2)
+    return (s1 > s2) & (s1.shift() < s2.shift()) 
+
+def crossunder(s1, s2):
+    if isinstance(s2, numbers.Number):
+        return (s1 < s2) & (s1.shift() > s2)
+    return (s1 < s2) & (s1.shift() > s2.shift()) 
 
 def is_evalable(obj):
     try:
@@ -46,7 +57,10 @@ def enumerate_variables(variables):
             and not isinstance(v, pd.DataFrame)):
 
             enumeration_name.append(name)
-            enumeration_vars.append(v)
+            if (isinstance(v, np.ndarray)):
+                enumeration_vars.append(v.tolist())
+            else:
+                enumeration_vars.append(v)
         else:
             constant_d[name] = v
 


### PR DESCRIPTION
fix : expect int but got int64 problem by using talib.STOCH, maybe other indicators will also encounter the same problem.
In addition, the commonly used cross function is also added to utility.py