### PR TITLE
Replace append dataframe by concat

### DIFF
--- a/finlab_crypto/crawler.py
+++ b/finlab_crypto/crawler.py
@@ -85,7 +85,7 @@ def get_all_binance(symbol, kline_size, save=True, client=Client()):
     data['timestamp'] = pd.to_datetime(data['timestamp'], unit='ms')
     if len(data_df) > 0:
         temp_df = pd.DataFrame(data)
-        data_df = data_df.append(temp_df)
+        data_df = pd.concat([data_df, temp_df])
     else:
         data_df = data
     data_df.set_index('timestamp', inplace=True)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/bangyuwen/Documents/Github/crypto-analysis/strategies/test.py", line 5, in <module>
    ohlcv = finlab_crypto.crawler.get_all_binance("BTCUSDT", "4h")
  File "/Users/bangyuwen/Documents/Github/crypto-analysis/.venv/lib/python3.10/site-packages/finlab_crypto/crawler.py", line 89, in get_all_binance
    data_df = data_df.append(temp_df)
  File "/Users/bangyuwen/Documents/Github/crypto-analysis/.venv/lib/python3.10/site-packages/pandas/core/generic.py", line 5989, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'append'. Did you mean: '_append'?
```